### PR TITLE
Vb/cliversion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject guidescan-web "2.0"
+(defproject guidescan-web "2.0.3"
   :description "Version 2.0 of the Guidescan website."
   :url "http://guidescan.com/"
   :author "Henri Schmidt"

--- a/src/guidescan_web/genomics/resolver.clj
+++ b/src/guidescan_web/genomics/resolver.clj
@@ -177,9 +177,9 @@
     (if-let [conns (get-in config [:config :sequence-resolvers])]
       (do
         (timbre/info "Checking sequence-resolvers")
-        (for [organism (keys conns)]
+        (doseq [organism (keys conns)]
           (if-not (resolve-sequence-raw (get-in conns [organism :url])
-                                        random-dna-seq)
+                                        (get-in conns [organism :seq] random-dna-seq))
             (timbre/warn
              (format
               "organism %s's search endpoint does not appear to be available"

--- a/src/guidescan_web/query/parsing.clj
+++ b/src/guidescan_web/query/parsing.clj
@@ -182,21 +182,6 @@
   [text]
   (re-matches #"^[atcgnATCGN\\R]+$" text))
 
-(defn- parse-dna-sequence
-  "Parses the text as a DNA sequence, resolving its coordinates using
-  the sequence-resolver component."
-  [{:keys [sequence-resolver]} organism text]
-  (let [dna (-> text
-                (clojure.string/replace #"\R" "")
-                (clojure.string/upper-case))
-        pretty-dna (if (> (count dna) 40)
-                     (format "%s...%s" (subs dna 0 20) (subs dna (- (count dna) 20)))
-                     dna)]
-    (if (> (count dna) 10)
-      (f/attempt-all [coords (resolver/resolve-sequence sequence-resolver organism dna)]
-        (convert-coords dna coords))
-      (f/fail "Input DNA sequence too short."))))
-
 (defn- parse-grnas
   [sequence-resolver organism text]
   (let [valid-grna? #(and (dna-seq? %)
@@ -239,9 +224,7 @@
 (defmethod parse-genomic-regions :text
   [resolver organism req]
   (f/if-let-ok? [query-text (parse-req-string :query-text req)]
-    (if (dna-seq? query-text)
-        (parse-dna-sequence resolver organism query-text)
-        (parse-raw-text query-text (partial parse-line resolver organism) false))))
+    (parse-raw-text query-text (partial parse-line resolver organism) false)))
 
 (defmethod parse-genomic-regions :text-file
   [resolver organism req]

--- a/src/guidescan_web/routes.clj
+++ b/src/guidescan_web/routes.clj
@@ -109,7 +109,7 @@
   {:supported [{:organism :enzyme}]}"
   [req config]
   (timbre/info "Info request from " (:remote-addr req) ".")
-  (let [json-obj {:version (-> "project.clj" slurp read-string (nth 2))
+  (let [json-obj {:version (if (.exists (clojure.java.io/file "project.clj")) (-> "project.clj" slurp read-string (nth 2)) "")
                   :cli-version (-> config :config (get-in [:guidescan-cli :path]) (utils/exec "--version") first first)
                   :available (keys (:grna-database-path-map (:config config)))}]
     (content-type 

--- a/src/guidescan_web/routes.clj
+++ b/src/guidescan_web/routes.clj
@@ -110,7 +110,7 @@
   [req config]
   (timbre/info "Info request from " (:remote-addr req) ".")
   (let [json-obj {:version (-> "project.clj" slurp read-string (nth 2))
-                  :cli-version (-> config :config (get-in [:guidescan-cli :path] "") (utils/exec_stdout "./guidescan" "--version") first)
+                  :cli-version (-> config :config (get-in [:guidescan-cli :path]) (utils/exec "--version") first first)
                   :available (keys (:grna-database-path-map (:config config)))}]
     (content-type 
      (response (cheshire/encode json-obj))

--- a/src/guidescan_web/routes.clj
+++ b/src/guidescan_web/routes.clj
@@ -14,7 +14,8 @@
    [taoensso.timbre :as timbre]
    [guidescan-web.genomics.resolver :as resolver]
    [guidescan-web.query.render :as render]
-   [guidescan-web.query.jobs :as jobs]))
+   [guidescan-web.query.jobs :as jobs]
+   [guidescan-web.utils :as utils]))
 
 (defn query-handler
   "Core of the Guidescan website. Exposes a REST handler that takes a
@@ -109,6 +110,7 @@
   [req config]
   (timbre/info "Info request from " (:remote-addr req) ".")
   (let [json-obj {:version (-> "project.clj" slurp read-string (nth 2))
+                  :cli-version (-> config :config (get-in [:guidescan-cli :path] "") (utils/exec_stdout "./guidescan" "--version") first)
                   :available (keys (:grna-database-path-map (:config config)))}]
     (content-type 
      (response (cheshire/encode json-obj))

--- a/src/guidescan_web/routes.clj
+++ b/src/guidescan_web/routes.clj
@@ -97,7 +97,7 @@
      (response (cheshire/encode suggestions))
      (render/get-content-type :json))))
 
-(defn supported-handler
+(defn- _supported-handler
   "Exposes a REST handler that returns the supported organisms and
   enzymes by this endpoint.
 
@@ -107,14 +107,15 @@
   HTTP Response Code: 200 OK
   JSON Response:
   {:supported [{:organism :enzyme}]}"
-  [req config]
-  (timbre/info "Info request from " (:remote-addr req) ".")
+  [config]
   (let [json-obj {:version (if (.exists (clojure.java.io/file "project.clj")) (-> "project.clj" slurp read-string (nth 2)) "")
                   :cli-version (-> config :config (get-in [:guidescan-cli :path]) (utils/exec "--version") first first)
                   :available (keys (:grna-database-path-map (:config config)))}]
     (content-type 
      (response (cheshire/encode json-obj))
      (render/get-content-type :json))))
+
+(def supported-handler (memoize _supported-handler))
 
 (defn examples-handler
   "Exposes a REST handler that returns example queries for
@@ -144,7 +145,7 @@
    (GET "/info/examples" req
         (examples-handler req config))
    (GET "/info/supported" req
-        (supported-handler req config))
+        (supported-handler config))
    (GET "/info/autocomplete" [organism symbol :as req]
         (autocomplete-handler gene-resolver req organism symbol))
    (route/not-found "404 page not found.")))

--- a/src/guidescan_web/utils.clj
+++ b/src/guidescan_web/utils.clj
@@ -68,9 +68,14 @@
       (reverse)
       (clojure.string/join)))
 
-(defn exec_stdout [dir command & args] (try (let [
-                                                  runtime (Runtime/getRuntime) proc (.exec runtime (into-array (cons command args)) nil (java.io.File. dir))
-                                                  stdout (.getInputStream proc)
-                                                  ret (.waitFor proc)
-                                                  out (line-seq (BufferedReader. (InputStreamReader. stdout)))
-                                                  ] out) (catch Exception e [""])))
+(defn exec
+  [command & args]
+  (try
+    (let [
+          runtime (Runtime/getRuntime) proc (.exec runtime (into-array (cons command args)) nil nil)
+          stdout (.getInputStream proc)
+          stderr (.getErrorStream proc)
+          ret (.waitFor proc)
+          stdout_str (line-seq (BufferedReader. (InputStreamReader. stdout)))
+          stderr_str (line-seq (BufferedReader. (InputStreamReader. stderr)))
+          ] [stdout_str stderr_str ret]) (catch Exception e ["" "" (.toString e)])))

--- a/src/guidescan_web/utils.clj
+++ b/src/guidescan_web/utils.clj
@@ -1,4 +1,5 @@
-(ns guidescan-web.utils)
+(ns guidescan-web.utils
+  (:import (java.io InputStreamReader BufferedReader)))
 
 (defmacro if-let*
   "Multiple binding version of if-let"
@@ -66,3 +67,10 @@
   (-> (map {\A \T \T \A \G \C \C \G \N \N} sequence)
       (reverse)
       (clojure.string/join)))
+
+(defn exec_stdout [dir command & args] (try (let [
+                                                  runtime (Runtime/getRuntime) proc (.exec runtime (into-array (cons command args)) nil (java.io.File. dir))
+                                                  stdout (.getInputStream proc)
+                                                  ret (.waitFor proc)
+                                                  out (line-seq (BufferedReader. (InputStreamReader. stdout)))
+                                                  ] out) (catch Exception e [""])))


### PR DESCRIPTION
Minor improvements:
- CLI Version reported at `info/supported` through a `utils.exec` utility that invokes `guidescan` and captures the `stdout`
- Web API Version that was previously supported is now more fault tolerant. (There is no `project.clj` in the uberjar).
- Results at `info/supported` are memoized since results are independent of request and we do not want to call `guidescan` repeatedly.
