### PR TITLE
Filtering out off-targets on chrs without an accession name

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject guidescan-web "2.0.3"
+(defproject guidescan-web "2.0.4"
   :description "Version 2.0 of the Guidescan website."
   :url "http://guidescan.com/"
   :author "Henri Schmidt"

--- a/src/guidescan_web/bam/db.clj
+++ b/src/guidescan_web/bam/db.clj
@@ -78,7 +78,9 @@
          (when-let [barray (.getAttribute bam-record "of")]
            {:off-targets (->> barray
                               (parse-offtarget-info genome-structure)
-                              (resolve-accession-names gene-resolver organism))})
+                              (resolve-accession-names gene-resolver organism)
+                              ; Filter out off-targets that don't have an accession name (on contigs/scaffolds)
+                              (filter #(not (nil? (:chromosome %)))))})
          (when-let [d0 (.getAttribute bam-record "k0")]
            {:distance-0-off-targets d0})
          (when-let [d1 (.getAttribute bam-record "k1")]


### PR DESCRIPTION
This is to remove the `chrnull` off-targets as reported in the web interface. Specificity/CFD calculations are unaffected, just that these off-targets are filtered out.

One case to see this on the site could be:
`sacCer3; cas9; chrIX:202200-202300` = currently reports 4 hits with `2:0, 3:2` as the off-targets on the last one.
After this change, it should be `2:0, 3:1` as the off-targets on the last one.