### PR TITLE
organism info returned for sequence resolution 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject guidescan-web "2.0.4"
+(defproject guidescan-web "2.0.5"
   :description "Version 2.0 of the Guidescan website."
   :url "http://guidescan.com/"
   :author "Henri Schmidt"

--- a/src/guidescan_web/bam/db.clj
+++ b/src/guidescan_web/bam/db.clj
@@ -67,7 +67,8 @@
                                
 (defn- parse-query-result
   [genome-structure gene-resolver organism bam-record]
-  (merge {:sequence (.getReadString bam-record)
+  (merge {:organism organism
+          :sequence (.getReadString bam-record)
           :start (.getAlignmentStart bam-record)
           :end (.getAlignmentEnd bam-record)
           :direction (if (.getReadNegativeStrandFlag bam-record) :negative :positive)}


### PR DESCRIPTION
To allow linking to the IGV viewer on the frontend for results obtained from a sequence search, we need to return the "organism" in addition to all the rest of the current data.