### PR TITLE
indexing fixes for legacy BAM dbs; visualization fix with IGV using B…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject guidescan-web "2.0.5"
+(defproject guidescan-web "2.0.6"
   :description "Version 2.0 of the Guidescan website."
   :url "http://guidescan.com/"
   :author "Henri Schmidt"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,6 +2,14 @@
  :available-cas-enzymes ["cas9"]
  :grna-database-path-prefix "/home/schmidt73/Desktop/guidescan-web/"
  :grna-database-path-map {{:organism "ce11" :enzyme "cas9"} "ce11.bam.sorted"}
+ ; The POS SAM field in some legacy grna dbs was 0-indexed instead of 1-indexed
+ ; (which is the normal behavior). This key specifies the organism/enzyme combination
+ ; with the offset that must be added to the observed POS field to get the
+ ; "true" alignment position.
+ :grna-database-offset-map  {{:organism "hg38" :enzyme "cas9"} 1
+                             {:organism "ce11" :enzyme "cpf1"} 1
+                             {:organism "hg38" :enzyme "cpf1"} 1
+                             {:organism "mm10" :enzyme "cpf1"} 1}
  :sequence-resolvers {"ce11" {:url "http://localhost:4500"}}
  :logfile "test.txt"
  :examples {"coords" {"ce11" {"cas9" "chrIV:1100-45001"}}

--- a/src/guidescan_web/config.clj
+++ b/src/guidescan_web/config.clj
@@ -33,3 +33,11 @@
        (contains? (:grna-database-path-map (:config config))
                   {:organism organism
                    :enzyme enzyme})))
+
+(defn get-grna-db-pos-offset
+  "Returns the offset that must be added to the observed
+  position of an alignment to get the true position."
+  [config organism enzyme]
+      (get (:grna-database-offset-map  (:config config))
+           {:organism organism
+            :enzyme enzyme} 0))

--- a/src/guidescan_web/query/render.clj
+++ b/src/guidescan_web/query/render.clj
@@ -98,11 +98,15 @@
   (map-indexed #(grna-to-csv-vector genomic-region %2 %1) grnas))
 
 (defn grna-to-bed-line
+  "BED files are 0-indexed, start-inclusive and end-exclusive.
+  We transform grna coordinates (1-indexed, start-inclusive, end-inclusive),
+  by subtracting 1 from :start, and leaving :end untouched.
+  Note that :start <= :end for grna coordinates no matter the direction."
   [chr grna]
   (let [[direction start end]
         (if (= (:direction grna) :positive)
-          ["+" (:start grna) (:end grna)]
-          ["-" (dec (:start grna)) (dec (:end grna))])
+          ["+" (dec (:start grna)) (:end grna)]
+          ["-" (dec (:start grna)) (:end grna)])
         name (str chr ":" (:start grna) "-" (:end grna))]
     (clojure.string/join
      "\t"


### PR DESCRIPTION
The IGV viewer regions being off by 1 (sometimes 2) is attributable to two reasons:
1. Some legacy BAM files being 0-indexed (cas9/hg38, cpf1/*) instead of 1-indexed.
2. The BED files that we generate need to be 0-indexed and end-exclusive as per spec. I believe this is the only format endpoint where the results of the job need to differ from the other format endpoints (csv/excel/json) where we can stick to the existing (1-indexed, both ends inclusive) values.